### PR TITLE
Added include path to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,6 @@
     },
     "autoload": {
         "psr-0": { "PEAR": "" }
-    }
+    },
+    "include-path": ["."]
 }


### PR DESCRIPTION
Normally PEAR allows loading files using a require statement (require_once('PEAR/...'). This will fail without the include path because PHP can not find the files because the inclusion is requested right away instead of relaying on the autoloader. Unfortunately a lot of PEAR packages use these statements, making this include path necessary to be fully usable as a composer package.
