### PR TITLE
Fixes PHP warning for 8.1+

### DIFF
--- a/PEAR/Exception.php
+++ b/PEAR/Exception.php
@@ -142,7 +142,7 @@ class PEAR_Exception extends Exception
             $code = null;
             $this->cause = null;
         }
-        parent::__construct($message, $code);
+        parent::__construct($message, (int) $code);
         $this->signal();
     }
 


### PR DESCRIPTION
Fixes PHP 8.1+ warning:
`Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated`
Related to https://github.com/phingofficial/phing/runs/1895709773