### PR TITLE
fixed composer `support.issues` url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "."
     ],
     "support": {
-        "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=PEAR_Exception",
+        "issues": "https://pear.php.net/bugs/search.php?cmd=display&package_name%5B%5D=PEAR_Exception",
         "source": "https://github.com/pear/PEAR_Exception"
     },
     "require-dev": {


### PR DESCRIPTION
* protocol "https" since the webserver at pear.php.net would send a HTTP status 301 with the new URL anyways
* escaped query string params according to [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986/#section-2.2)
